### PR TITLE
[WIP] Add option to listen to other hostname different to localhost

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -18,7 +18,7 @@ type localListener struct {
 // If nil or an empty slice is given, it will allocate a free port.
 func newLocalListener(host string, ports []int) (*localListener, error) {
 	if len(ports) == 0 {
-		return newLocalListenerAt(host,0)
+		return newLocalListenerAt(host, 0)
 	}
 	var errs []string
 	for _, port := range ports {
@@ -39,6 +39,6 @@ func newLocalListenerAt(host string, port int) (*localListener, error) {
 	}
 	addr := l.Addr().String()
 	_, p, err := net.SplitHostPort(addr)
-	url := fmt.Sprintf("http://%s:%s", host, p)
+	url := fmt.Sprintf("http://localhost:%s", p)
 	return &localListener{l, url}, nil
 }

--- a/listener.go
+++ b/listener.go
@@ -8,21 +8,21 @@ import (
 	"golang.org/x/xerrors"
 )
 
-type localhostListener struct {
+type localListener struct {
 	net.Listener
 	URL string
 }
 
-// newLocalhostListener starts a TCP listener on localhost.
+// newLocalListener starts a TCP listener on localhost.
 // If multiple ports are given, it will try the ports in order.
 // If nil or an empty slice is given, it will allocate a free port.
-func newLocalhostListener(ports []int) (*localhostListener, error) {
+func newLocalListener(host string, ports []int) (*localListener, error) {
 	if len(ports) == 0 {
-		return newLocalhostListenerAt(0)
+		return newLocalListenerAt(host,0)
 	}
 	var errs []string
 	for _, port := range ports {
-		l, err := newLocalhostListenerAt(port)
+		l, err := newLocalListenerAt(host, port)
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -32,16 +32,13 @@ func newLocalhostListener(ports []int) (*localhostListener, error) {
 	return nil, xerrors.Errorf("no available port (%s)", strings.Join(errs, ", "))
 }
 
-func newLocalhostListenerAt(port int) (*localhostListener, error) {
-	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+func newLocalListenerAt(host string, port int) (*localListener, error) {
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, xerrors.Errorf("could not listen: %w", err)
 	}
 	addr := l.Addr().String()
 	_, p, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, xerrors.Errorf("could not parse the address %s: %w", addr, err)
-	}
-	url := fmt.Sprintf("http://localhost:%s", p)
-	return &localhostListener{l, url}, nil
+	url := fmt.Sprintf("http://%s:%s", host, p)
+	return &localListener{l, url}, nil
 }

--- a/listener.go
+++ b/listener.go
@@ -13,7 +13,7 @@ type localListener struct {
 	URL string
 }
 
-// newLocalListener starts a TCP listener on localhost.
+// newLocalListener starts a TCP listener on the given host.
 // If multiple ports are given, it will try the ports in order.
 // If nil or an empty slice is given, it will allocate a free port.
 func newLocalListener(host string, ports []int) (*localListener, error) {

--- a/listener_test.go
+++ b/listener_test.go
@@ -7,9 +7,9 @@ import (
 
 func Test_newLocalhostListener(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
-		l, err := newLocalhostListener(nil)
+		l, err := newLocalListener("localhost", nil)
 		if err != nil {
-			t.Fatalf("newLocalhostListener error: %s", err)
+			t.Fatalf("newLocalListener error: %s", err)
 		}
 		defer l.Close()
 		if l.URL == "" {
@@ -19,9 +19,9 @@ func Test_newLocalhostListener(t *testing.T) {
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		l, err := newLocalhostListener(nil)
+		l, err := newLocalListener("localhost", nil)
 		if err != nil {
-			t.Fatalf("newLocalhostListener error: %s", err)
+			t.Fatalf("newLocalListener error: %s", err)
 		}
 		defer l.Close()
 		if l.URL == "" {
@@ -31,9 +31,9 @@ func Test_newLocalhostListener(t *testing.T) {
 	})
 
 	t.Run("singlePort", func(t *testing.T) {
-		l, err := newLocalhostListener([]int{9000})
+		l, err := newLocalListener("localhost", []int{9000})
 		if err != nil {
-			t.Fatalf("newLocalhostListener error: %s", err)
+			t.Fatalf("newLocalListener error: %s", err)
 		}
 		defer l.Close()
 		if w := "http://localhost:9000"; l.URL != w {
@@ -48,9 +48,9 @@ func Test_newLocalhostListener(t *testing.T) {
 		}
 		defer preListener.Close()
 
-		l, err := newLocalhostListener([]int{9000, 9001})
+		l, err := newLocalListener("localhost", []int{9000, 9001})
 		if err != nil {
-			t.Fatalf("newLocalhostListener error: %s", err)
+			t.Fatalf("newLocalListener error: %s", err)
 		}
 		defer l.Close()
 		if w := "http://localhost:9001"; l.URL != w {
@@ -70,10 +70,10 @@ func Test_newLocalhostListener(t *testing.T) {
 		}
 		defer preListener2.Close()
 
-		l, err := newLocalhostListener([]int{9001, 9002})
+		l, err := newLocalListener("localhost", []int{9001, 9002})
 		if err == nil {
 			l.Close()
-			t.Fatalf("newLocalhostListener wants error but nil")
+			t.Fatalf("newLocalListener wants error but nil")
 		}
 		t.Logf("expected error: %s", err)
 	})

--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -26,6 +26,10 @@ type Config struct {
 	// If multiple ports are given, it will try the ports in order.
 	// If nil or an empty slice is given, it will allocate a free port.
 	LocalServerPort []int
+	// Set the hostname to listen to.
+	// If false value is given, it will listen to 'localhost' only.
+	// If true value is given, it will listen in any hostname.
+	LocalServerListenAnyHost bool
 	// Response HTML body on authorization completed.
 	// Default to DefaultLocalServerSuccessHTML.
 	LocalServerSuccessHTML string
@@ -33,6 +37,13 @@ type Config struct {
 	LocalServerMiddleware func(h http.Handler) http.Handler
 	// A channel to send its URL when the local server is ready. Default to none.
 	LocalServerReadyChan chan<- string
+}
+
+func (c *Config) localServerHost() string {
+	if c.LocalServerListenAnyHost {
+		return ""
+	}
+	return "localhost"
 }
 
 // GetToken performs Authorization Code Grant Flow and returns a token got from the provider.

--- a/server.go
+++ b/server.go
@@ -16,7 +16,7 @@ func receiveCodeViaLocalServer(ctx context.Context, c *Config) (string, error) {
 	if err != nil {
 		return "", xerrors.Errorf("error while state parameter generation: %w", err)
 	}
-	listener, err := newLocalhostListener(c.LocalServerPort)
+	listener, err := newLocalListener(c.localServerHost(), c.LocalServerPort)
 	if err != nil {
 		return "", xerrors.Errorf("error while starting a local server: %w", err)
 	}


### PR DESCRIPTION
It tries to solve issue #4 by adding a new option `LocalServerListenAnyHost`.

It maintains backwards compatibility, so the default behaviour is listen to `localhost` only.

This new behaviour will allow to run this `oauth2cli` inside a docker and be successful to finish OAuth process.