### PR TITLE
Add TokenRequestOptions for PKCE

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -21,9 +21,23 @@ Build and run the application:
 
 It will automatically open the browser and you can log in to Google.
 
-As well as you can set a certificate and key for the local server.
+### Use a TLS certificate
+
+You can set a certificate and key for the local server.
+
+```sh
+./example -client-id xxx.apps.googleusercontent.com -client-secret xxxxxxxx \
+  -local-server-cert ../testdata/cert.pem -local-server-key ../testdata/cert-key.pem
+```
+
+### Use PKCE
+
+This example uses the Okta.
+You need to setup [your application with PKCE](https://developer.okta.com/docs/guides/implement-auth-code-pkce/overview/) on your account.
 
 ```
-% ./example -client-id xxx.apps.googleusercontent.com -client-secret xxxxxxxx \
-    -local-server-cert ../testdata/cert.pem -local-server-key ../testdata/cert-key.pem
+./example -pkce -scopes email,openid \
+  -auth-url https://xxxxxxxx.okta.com/oauth2/default/v1/authorize \
+  -token-url https://xxxxxxxx.okta.com/oauth2/default/v1/token \
+  -client-id xxxxxxxx
 ```

--- a/example/main.go
+++ b/example/main.go
@@ -3,31 +3,41 @@ package main
 import (
 	"context"
 	"flag"
+	"log"
+	"os"
+	"strings"
+
 	"github.com/int128/oauth2cli"
 	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
-	"log"
-	"os"
 )
 
 type cmdOptions struct {
+	authURL         string
+	tokenURL        string
 	clientID        string
 	clientSecret    string
+	scopes          string
+	usePKCE         bool
 	localServerCert string
 	localServerKey  string
 }
 
 func main() {
 	var o cmdOptions
+	flag.StringVar(&o.authURL, "auth-url", google.Endpoint.AuthURL, "Authorization URL of the endpoint")
+	flag.StringVar(&o.tokenURL, "token-url", google.Endpoint.TokenURL, "Authorization URL of the endpoint")
 	flag.StringVar(&o.clientID, "client-id", "", "OAuth Client ID")
-	flag.StringVar(&o.clientSecret, "client-secret", "", "OAuth Client Secret")
+	flag.StringVar(&o.clientSecret, "client-secret", "", "OAuth Client Secret (optional)")
+	flag.StringVar(&o.scopes, "scopes", "email", "Scopes to request, comma separated")
+	flag.BoolVar(&o.usePKCE, "pkce", false, "Enable PKCE")
 	flag.StringVar(&o.localServerCert, "local-server-cert", "", "Path to a certificate file for the local server (optional)")
 	flag.StringVar(&o.localServerKey, "local-server-key", "", "Path to a key file for the local server (optional)")
 	flag.Parse()
-	if o.clientID == "" || o.clientSecret == "" {
+	if o.clientID == "" {
 		log.Printf(`You need to set oauth2 credentials.
 Open https://console.cloud.google.com/apis/credentials and create a client.
 Then set the following options:`)
@@ -35,14 +45,33 @@ Then set the following options:`)
 		os.Exit(1)
 		return
 	}
+
+	ready := make(chan string, 1)
+	defer close(ready)
+	cfg := oauth2cli.Config{
+		OAuth2Config: oauth2.Config{
+			ClientID:     o.clientID,
+			ClientSecret: o.clientSecret,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  o.authURL,
+				TokenURL: o.tokenURL,
+			},
+			Scopes: strings.Split(o.scopes, ","),
+		},
+		LocalServerPort:      []int{8000, 18000},
+		LocalServerReadyChan: ready,
+		LocalServerCertFile:  o.localServerCert,
+		LocalServerKeyFile:   o.localServerKey,
+	}
 	if o.localServerCert != "" {
-		log.Printf("Using a TLS certificate: %s", o.localServerCert)
+		log.Printf("Using the TLS certificate: %s", o.localServerCert)
+	}
+	if o.usePKCE {
+		configurePKCE(&cfg)
 	}
 
 	ctx := context.Background()
 	eg, ctx := errgroup.WithContext(ctx)
-	ready := make(chan string, 1)
-	defer close(ready)
 	eg.Go(func() error {
 		select {
 		case url := <-ready:
@@ -56,17 +85,7 @@ Then set the following options:`)
 		}
 	})
 	eg.Go(func() error {
-		token, err := oauth2cli.GetToken(ctx, oauth2cli.Config{
-			OAuth2Config: oauth2.Config{
-				ClientID:     o.clientID,
-				ClientSecret: o.clientSecret,
-				Endpoint:     google.Endpoint,
-				Scopes:       []string{"email"},
-			},
-			LocalServerReadyChan: ready,
-			LocalServerCertFile:  o.localServerCert,
-			LocalServerKeyFile:   o.localServerKey,
-		})
+		token, err := oauth2cli.GetToken(ctx, cfg)
 		if err != nil {
 			return xerrors.Errorf("could not get a token: %w", err)
 		}

--- a/example/pkce.go
+++ b/example/pkce.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"log"
+	"strings"
+
+	"github.com/int128/oauth2cli"
+	"golang.org/x/oauth2"
+)
+
+func configurePKCE(cfg *oauth2cli.Config) {
+	b := make([]byte, 32)
+	if err := binary.Read(rand.Reader, binary.LittleEndian, b); err != nil {
+		log.Fatalf("error: %s", err)
+	}
+	codeChallenge, codeVerifier := computeChallengeAndVerifier(b)
+	cfg.AuthCodeOptions = []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+		oauth2.SetAuthURLParam("code_challenge", codeChallenge),
+	}
+	cfg.TokenRequestOptions = []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("code_verifier", codeVerifier),
+	}
+}
+
+func computeChallengeAndVerifier(b []byte) (string, string) {
+	verifier := base64urlencode(b)
+	s := sha256.New()
+	s.Write([]byte(verifier))
+	challenge := base64urlencode(s.Sum(nil))
+	return challenge, verifier
+}
+
+func base64urlencode(b []byte) string {
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
+}

--- a/example/pkce.go
+++ b/example/pkce.go
@@ -30,7 +30,7 @@ func configurePKCE(cfg *oauth2cli.Config) {
 func computeChallengeAndVerifier(b []byte) (string, string) {
 	verifier := base64urlencode(b)
 	s := sha256.New()
-	s.Write([]byte(verifier))
+	_, _ = s.Write([]byte(verifier))
 	challenge := base64urlencode(s.Sum(nil))
 	return challenge, verifier
 }

--- a/example/pkce_test.go
+++ b/example/pkce_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func Test_computeChallengeAndVerifier(t *testing.T) {
+	// https://tools.ietf.org/html/rfc7636#appendix-B
+	b := []byte{
+		116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173,
+		187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83,
+		132, 141, 121,
+	}
+	challenge, verifier := computeChallengeAndVerifier(b)
+	if want := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"; want != verifier {
+		t.Errorf("verifier wants %s but was %s", want, verifier)
+	}
+	if want := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"; want != challenge {
+		t.Errorf("challenge wants %s but was %s", want, challenge)
+	}
+}

--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -19,8 +19,14 @@ const DefaultLocalServerSuccessHTML = `<html><body>OK<script>window.close()</scr
 
 // Config represents a config for GetToken.
 type Config struct {
-	OAuth2Config    oauth2.Config
+	OAuth2Config oauth2.Config
+
+	// Options for an authorization request.
+	// You can set oauth2.AccessTypeOffline and the PKCE options here.
 	AuthCodeOptions []oauth2.AuthCodeOption
+	// Options for a token request.
+	// You can set the PKCE options here.
+	TokenRequestOptions []oauth2.AuthCodeOption
 
 	// Address which the local server binds to.
 	// Set to "0.0.0.0" to bind all interfaces.
@@ -70,7 +76,7 @@ func GetToken(ctx context.Context, config Config) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("error while receiving an authorization code: %w", err)
 	}
-	token, err := config.OAuth2Config.Exchange(ctx, code)
+	token, err := config.OAuth2Config.Exchange(ctx, code, config.TokenRequestOptions...)
 	if err != nil {
 		return nil, xerrors.Errorf("error while exchanging authorization code and token: %w", err)
 	}


### PR DESCRIPTION
This adds `TokenRequestOptions` to the config for [PKCE](https://tools.ietf.org/html/rfc7636) support. Also adds an example.