### PR TITLE
Fix backward compatibility of LocalServerAddress, LocalServerPort

### DIFF
--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -53,18 +53,24 @@ type Config struct {
 	// DEPRECATED: this will be removed in the future release.
 	// Use LocalServerBindAddress instead.
 	// Address which the local server binds to.
+	// Default to "127.0.0.1".
 	LocalServerAddress string
 	// DEPRECATED: this will be removed in the future release.
 	// Use LocalServerBindAddress instead.
 	// Candidates of a port which the local server binds to.
-	// If multiple ports are given, it will try the ports in order.
+	// If nil or an empty slice is given, LocalServerAddress is ignored and allocate a free port.
+	// If multiple ports are given, they are appended to LocalServerBindAddress.
 	LocalServerPort []int
 }
 
 func (c *Config) populateDeprecatedFields() {
 	if len(c.LocalServerPort) > 0 {
+		address := c.LocalServerAddress
+		if address == "" {
+			address = "127.0.0.1"
+		}
 		for _, port := range c.LocalServerPort {
-			c.LocalServerBindAddress = append(c.LocalServerBindAddress, fmt.Sprintf("%s:%d", c.LocalServerAddress, port))
+			c.LocalServerBindAddress = append(c.LocalServerBindAddress, fmt.Sprintf("%s:%d", address, port))
 		}
 	}
 }

--- a/oauth2cli_test.go
+++ b/oauth2cli_test.go
@@ -16,12 +16,23 @@ func TestConfig_populateDeprecatedFields(t *testing.T) {
 		}
 	})
 
+	t.Run("AddressOnly", func(t *testing.T) {
+		cfg := Config{
+			LocalServerAddress: "0.0.0.0",
+		}
+		cfg.populateDeprecatedFields()
+		var want []string
+		if diff := cmp.Diff(want, cfg.LocalServerBindAddress); diff != "" {
+			t.Errorf("LocalServerBindAddress mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("SinglePort", func(t *testing.T) {
 		cfg := Config{
 			LocalServerPort: []int{8000},
 		}
 		cfg.populateDeprecatedFields()
-		want := []string{":8000"}
+		want := []string{"127.0.0.1:8000"}
 		if diff := cmp.Diff(want, cfg.LocalServerBindAddress); diff != "" {
 			t.Errorf("LocalServerBindAddress mismatch (-want +got):\n%s", diff)
 		}
@@ -29,11 +40,11 @@ func TestConfig_populateDeprecatedFields(t *testing.T) {
 
 	t.Run("SinglePortWithAddress", func(t *testing.T) {
 		cfg := Config{
-			LocalServerAddress: "127.0.0.1",
+			LocalServerAddress: "0.0.0.0",
 			LocalServerPort:    []int{8000},
 		}
 		cfg.populateDeprecatedFields()
-		want := []string{"127.0.0.1:8000"}
+		want := []string{"0.0.0.0:8000"}
 		if diff := cmp.Diff(want, cfg.LocalServerBindAddress); diff != "" {
 			t.Errorf("LocalServerBindAddress mismatch (-want +got):\n%s", diff)
 		}
@@ -44,7 +55,7 @@ func TestConfig_populateDeprecatedFields(t *testing.T) {
 			LocalServerPort: []int{8000, 18000},
 		}
 		cfg.populateDeprecatedFields()
-		want := []string{":8000", ":18000"}
+		want := []string{"127.0.0.1:8000", "127.0.0.1:18000"}
 		if diff := cmp.Diff(want, cfg.LocalServerBindAddress); diff != "" {
 			t.Errorf("LocalServerBindAddress mismatch (-want +got):\n%s", diff)
 		}
@@ -52,11 +63,11 @@ func TestConfig_populateDeprecatedFields(t *testing.T) {
 
 	t.Run("MultiplePortWithAddress", func(t *testing.T) {
 		cfg := Config{
-			LocalServerAddress: "127.0.0.1",
+			LocalServerAddress: "0.0.0.0",
 			LocalServerPort:    []int{8000, 18000},
 		}
 		cfg.populateDeprecatedFields()
-		want := []string{"127.0.0.1:8000", "127.0.0.1:18000"}
+		want := []string{"0.0.0.0:8000", "0.0.0.0:18000"}
 		if diff := cmp.Diff(want, cfg.LocalServerBindAddress); diff != "" {
 			t.Errorf("LocalServerBindAddress mismatch (-want +got):\n%s", diff)
 		}
@@ -80,7 +91,7 @@ func TestConfig_populateDeprecatedFields(t *testing.T) {
 				LocalServerPort:        []int{8000},
 			}
 			cfg.populateDeprecatedFields()
-			want := []string{"127.0.0.1:10000", ":8000"}
+			want := []string{"127.0.0.1:10000", "127.0.0.1:8000"}
 			if diff := cmp.Diff(want, cfg.LocalServerBindAddress); diff != "" {
 				t.Errorf("LocalServerBindAddress mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
This will fix backward compatibility of the fields: LocalServerAddress, LocalServerPort.
The default address should be "127.0.0.1" but was an empty (that is 0.0.0.0).