### PR TITLE
Improve default authorization success page

### DIFF
--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -14,7 +14,38 @@ import (
 var noopMiddleware = func(h http.Handler) http.Handler { return h }
 
 // DefaultLocalServerSuccessHTML is a default response body on authorization success.
-const DefaultLocalServerSuccessHTML = `<html><body>OK<script>window.close()</script></body></html>`
+const DefaultLocalServerSuccessHTML = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Authorized</title>
+	<script>
+		window.close()
+	</script>
+	<style>
+		body {
+			background-color: #eee;
+			margin: 0;
+			padding: 0;
+			font-family: sans-serif;
+		}
+		.placeholder {
+			margin: 2em;
+			padding: 2em;
+			background-color: #fff;
+			border-radius: 1em;
+		}
+	</style>
+</head>
+<body>
+	<div class="placeholder">
+		<h1>Authorized</h1>
+		<p>You can close this window.</p>
+	</div>
+</body>
+</html>
+`
 
 // Config represents a config for GetToken.
 type Config struct {


### PR DESCRIPTION
This will change the default authorization success page more descriptive.

See also https://github.com/int128/kubelogin/pull/312.

![image](https://user-images.githubusercontent.com/321266/86596324-fbff3580-bfd4-11ea-9287-d22476521841.png)
