### PR TITLE
Add option to specify failure and redirect uris

### DIFF
--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -89,6 +89,11 @@ type Config struct {
 	// A channel to send its URL when the local server is ready. Default to none.
 	LocalServerReadyChan chan<- string
 
+	// Redirect URL upon successful login
+	SuccessRedirectUrl string
+	// Redirect URL upon failed login
+	FailureRedirectUrl string
+
 	// Logger function for debug.
 	Logf func(format string, args ...interface{})
 }
@@ -117,6 +122,10 @@ func (c *Config) validateAndSetDefaults() error {
 	}
 	if c.LocalServerSuccessHTML == "" {
 		c.LocalServerSuccessHTML = DefaultLocalServerSuccessHTML
+	}
+	if (c.SuccessRedirectUrl != "" && c.FailureRedirectUrl == "") ||
+		(c.SuccessRedirectUrl == "" && c.FailureRedirectUrl != "") {
+		return fmt.Errorf("when using success and failure redirect URLs, set both URLs")
 	}
 	if c.Logf == nil {
 		c.Logf = func(string, ...interface{}) {}


### PR DESCRIPTION
For our use case, we wanted to be able to redirect the user to specific success and failure pages in the browser (very similar to the `gcloud` cli, i.e. https://cloud.google.com/sdk/auth_success and https://cloud.google.com/sdk/auth_failure).

This pull request includes the option to do just that, redirect the user to these pages based on the login result. If the values are omitted, then the regular flow that the `oauth2cli` library provides is followed.