### PR TITLE
Fix name to consistent case

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -219,8 +219,8 @@ func TestSuccessRedirect(t *testing.T) {
 			},
 			LocalServerReadyChan:  openBrowserCh,
 			LocalServerMiddleware: loggingMiddleware(t),
-			SuccessRedirectUrl:    sr.URL + "/success",
-			FailureRedirectUrl:    sr.URL + "/failure",
+			SuccessRedirectURL:    sr.URL + "/success",
+			FailureRedirectURL:    sr.URL + "/failure",
 			Logf:                  t.Logf,
 		}
 		token, err := oauth2cli.GetToken(ctx, cfg)

--- a/e2e_test/error_test.go
+++ b/e2e_test/error_test.go
@@ -109,8 +109,8 @@ func TestFailureRedirect(t *testing.T) {
 				},
 			},
 			LocalServerReadyChan: openBrowserCh,
-			SuccessRedirectUrl:   sr.URL + "/success",
-			FailureRedirectUrl:   sr.URL + "/failure",
+			SuccessRedirectURL:   sr.URL + "/success",
+			FailureRedirectURL:   sr.URL + "/failure",
 			Logf:                 t.Logf,
 		}
 		_, err := oauth2cli.GetToken(ctx, cfg)

--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -90,9 +90,9 @@ type Config struct {
 	LocalServerReadyChan chan<- string
 
 	// Redirect URL upon successful login
-	SuccessRedirectUrl string
+	SuccessRedirectURL string
 	// Redirect URL upon failed login
-	FailureRedirectUrl string
+	FailureRedirectURL string
 
 	// Logger function for debug.
 	Logf func(format string, args ...interface{})
@@ -123,8 +123,8 @@ func (c *Config) validateAndSetDefaults() error {
 	if c.LocalServerSuccessHTML == "" {
 		c.LocalServerSuccessHTML = DefaultLocalServerSuccessHTML
 	}
-	if (c.SuccessRedirectUrl != "" && c.FailureRedirectUrl == "") ||
-		(c.SuccessRedirectUrl == "" && c.FailureRedirectUrl != "") {
+	if (c.SuccessRedirectURL != "" && c.FailureRedirectURL == "") ||
+		(c.SuccessRedirectURL == "" && c.FailureRedirectURL != "") {
 		return fmt.Errorf("when using success and failure redirect URLs, set both URLs")
 	}
 	if c.Logf == nil {

--- a/server.go
+++ b/server.go
@@ -145,8 +145,8 @@ func (h *localServerHandler) handleCodeResponse(w http.ResponseWriter, r *http.R
 		return &authorizationResponse{err: fmt.Errorf("state does not match (wants %s but got %s)", h.config.State, state)}
 	}
 
-	if h.config.SuccessRedirectUrl != "" {
-		http.Redirect(w, r, h.config.SuccessRedirectUrl, http.StatusFound)
+	if h.config.SuccessRedirectURL != "" {
+		http.Redirect(w, r, h.config.SuccessRedirectURL, http.StatusFound)
 	} else {
 		w.Header().Add("Content-Type", "text/html")
 		if _, err := fmt.Fprintf(w, h.config.LocalServerSuccessHTML); err != nil {
@@ -167,8 +167,8 @@ func (h *localServerHandler) handleErrorResponse(w http.ResponseWriter, r *http.
 }
 
 func (h *localServerHandler) authorizationError(w http.ResponseWriter, r *http.Request) {
-	if h.config.FailureRedirectUrl != "" {
-		http.Redirect(w, r, h.config.FailureRedirectUrl, http.StatusFound)
+	if h.config.FailureRedirectURL != "" {
+		http.Redirect(w, r, h.config.FailureRedirectURL, http.StatusFound)
 	} else {
 		http.Error(w, "authorization error", 500)
 	}


### PR DESCRIPTION
Follow up https://github.com/int128/oauth2cli/pull/54.

>Words in names that are initialisms or acronyms (e.g. "URL" or "NATO") have a consistent case. For example, "URL" should appear as "URL" or "url" (as in "urlPony", or "URLPony"), never as "Url".
>https://github.com/golang/go/wiki/CodeReviewComments#initialisms