### PR TITLE
add GetCode

### DIFF
--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -160,3 +160,16 @@ func GetToken(ctx context.Context, c Config) (*oauth2.Token, error) {
 	}
 	return token, nil
 }
+
+
+func GetCode(ctx context.Context, c Config) (string, error) {
+	if err := c.validateAndSetDefaults(); err != nil {
+		return "", fmt.Errorf("invalid config: %w", err)
+	}
+	code, err := receiveCodeViaLocalServer(ctx, &c)
+	if err != nil {
+		return "", fmt.Errorf("authorization error: %w", err)
+	}
+
+	return code, nil
+}


### PR DESCRIPTION
Just get code instead of the token, the use case is it can help avoid client-secret hard-coded in Cli, Cli can then request the server which has the secret to relay the flow for exchanging the token.