### PR TITLE
add redirect url

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -164,6 +164,83 @@ func TestRedirectURLHostname(t *testing.T) {
 	wg.Wait()
 }
 
+func TestRedirectURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+	defer cancel()
+	openBrowserCh := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		defer close(openBrowserCh)
+		redirectURL := "http://localhost:8888"
+
+		// Start a local server and get a token.
+		s := httptest.NewServer(&authserver.Handler{
+			T: t,
+			NewAuthorizationResponse: func(r authserver.AuthorizationRequest) string {
+				if w := "email profile"; r.Scope != w {
+					t.Errorf("scope wants %s but %s", w, r.Scope)
+					return fmt.Sprintf("%s?error=invalid_scope", r.RedirectURI)
+				}
+				if r.RedirectURI != redirectURL {
+					t.Errorf("redirect_uri should be %s but was %s", redirectURL, r.RedirectURI)
+					return fmt.Sprintf("%s?error=invalid_redirect_uri", r.RedirectURI)
+				}
+				return fmt.Sprintf("%s?state=%s&code=%s", r.RedirectURI, r.State, "AUTH_CODE")
+			},
+			NewTokenResponse: func(r authserver.TokenRequest) (int, string) {
+				if w := "AUTH_CODE"; r.Code != w {
+					t.Errorf("code wants %s but %s", w, r.Code)
+					return 400, invalidGrantResponse
+				}
+				return 200, validTokenResponse
+			},
+		})
+		defer s.Close()
+		cfg := oauth2cli.Config{
+			OAuth2Config: oauth2.Config{
+				ClientID:     "YOUR_CLIENT_ID",
+				ClientSecret: "YOUR_CLIENT_SECRET",
+				Scopes:       []string{"email", "profile"},
+				Endpoint: oauth2.Endpoint{
+					AuthURL:  s.URL + "/auth",
+					TokenURL: s.URL + "/token",
+				},
+			},
+			LocalServerBindAddress: []string{"127.0.0.1:8888"},
+			RedirectURLHostname:    "127.0.0.1", // should be ignored as RedirectURL will override
+			RedirectURL:            redirectURL,
+			LocalServerReadyChan:   openBrowserCh,
+			LocalServerMiddleware:  loggingMiddleware(t),
+			Logf:                   t.Logf,
+		}
+		token, err := oauth2cli.GetToken(ctx, cfg)
+		if err != nil {
+			t.Errorf("could not get a token: %s", err)
+			return
+		}
+		if "ACCESS_TOKEN" != token.AccessToken {
+			t.Errorf("AccessToken wants %s but %s", "ACCESS_TOKEN", token.AccessToken)
+		}
+		if "REFRESH_TOKEN" != token.RefreshToken {
+			t.Errorf("RefreshToken wants %s but %s", "REFRESH_TOKEN", token.AccessToken)
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		toURL, ok := <-openBrowserCh
+		if !ok {
+			t.Errorf("server already closed")
+			return
+		}
+		client.GetAndVerify(t, toURL, 200, oauth2cli.DefaultLocalServerSuccessHTML)
+	}()
+	wg.Wait()
+}
+
 func TestSuccessRedirect(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
 	defer cancel()

--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -56,6 +56,9 @@ type Config struct {
 	// You can set this if your provider does not accept localhost.
 	// Default to localhost.
 	RedirectURLHostname string
+	// FQDN of redirect url
+	// This option will override `RedirectURLHostname` + port
+	RedirectURL string
 	// Options for an authorization request.
 	// You can set oauth2.AccessTypeOffline and the PKCE options here.
 	AuthCodeOptions []oauth2.AuthCodeOption

--- a/server.go
+++ b/server.go
@@ -94,6 +94,9 @@ func receiveCodeViaLocalServer(ctx context.Context, c *Config) (string, error) {
 }
 
 func computeRedirectURL(l net.Listener, c *Config) string {
+	if c.RedirectURL != "" {
+		return c.RedirectURL
+	}
 	hostPort := fmt.Sprintf("%s:%d", c.RedirectURLHostname, l.Addr().(*net.TCPAddr).Port)
 	if c.LocalServerCertFile != "" {
 		return "https://" + hostPort


### PR DESCRIPTION
# Use case

I deployed
- a [code-server](https://github.com/coder/code-server) running http on port 8209
- it behinds a reversed-proxy with SSL termination (ex: nginx, cloudflare tunnel) running https on port 443

I'm accessing it with https://dev2.tuana9a.com from any of mine devices that has a web browser (desktop, tablet, laptop, phone).

In this server I want to use [kubelogin](https://github.com/int128/kubelogin) to access my internal kubernetes cluster. The kubelogin will listen on port `8000` and that server doesn't have a browser so I skip the open browser step and instead, when the cli run, It should show the url bellow

```txt
Please visit the following URL in your browser: https://dev2-8000.tuana9a.com
```

The vscode-server support exposing port over a [custom proxy](https://coder.com/docs/code-server/guide#using-your-own-proxy) like

`VSCODE_PROXY_URI=https://dev2-{{port}}.tuana9a.com`

So that I can go to that url and access the temporary server opened by this oauth2cli and continue the process of authentication.

Current setup only have redirect hostname + port, I think by adding a `RedirectUrl` and let the user decide it could improve the flexibility of the cli.

If this go through I would love to open my next PR to add this flag `--oidc-redirect-url` to the `kubelogin` cli also. The full config look like this

```yaml
- name: oidc
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      args:
      - oidc-login
      - get-token
      - --oidc-issuer-url=https://accounts.google.com
      - --oidc-client-id=xxxx-yyy.apps.googleusercontent.com
      - --oidc-client-secret=zzz
      - --skip-open-browser
      - --listen-address=0.0.0.0:8000
      - --oidc-redirect-url=https://dev2-8000.tuana9a.com
      command: kubectl
      env: null
      interactiveMode: IfAvailable
      provideClusterInfo: false
```

# Tests

I have successfully modified the code andI have written e2e test for this usecase and it passed.

# Related

This PR may be related to #137 and #117 
