### PR TITLE
Fix backward compatibility of LocalServerCallbackPath

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -36,7 +36,7 @@ func TestHappyPath(t *testing.T) {
 					t.Errorf("scope wants %s but %s", want, req.Scope)
 					return fmt.Sprintf("%s?error=invalid_scope", req.RedirectURI)
 				}
-				if !assertRedirectURI(t, req.RedirectURI, "http", "localhost", "/") {
+				if !assertRedirectURI(t, req.RedirectURI, "http", "localhost", "") {
 					return fmt.Sprintf("%s?error=invalid_redirect_uri", req.RedirectURI)
 				}
 				return fmt.Sprintf("%s?state=%s&code=%s", req.RedirectURI, req.State, "AUTH_CODE")
@@ -106,7 +106,7 @@ func TestRedirectURLHostname(t *testing.T) {
 					t.Errorf("scope wants %s but %s", want, req.Scope)
 					return fmt.Sprintf("%s?error=invalid_scope", req.RedirectURI)
 				}
-				if !assertRedirectURI(t, req.RedirectURI, "http", "127.0.0.1", "/") {
+				if !assertRedirectURI(t, req.RedirectURI, "http", "127.0.0.1", "") {
 					return fmt.Sprintf("%s?error=invalid_redirect_uri", req.RedirectURI)
 				}
 				return fmt.Sprintf("%s?state=%s&code=%s", req.RedirectURI, req.State, "AUTH_CODE")
@@ -177,7 +177,7 @@ func TestSuccessRedirect(t *testing.T) {
 					t.Errorf("scope wants %s but %s", want, req.Scope)
 					return fmt.Sprintf("%s?error=invalid_scope", req.RedirectURI)
 				}
-				if !assertRedirectURI(t, req.RedirectURI, "http", "localhost", "/") {
+				if !assertRedirectURI(t, req.RedirectURI, "http", "localhost", "") {
 					return fmt.Sprintf("%s?error=invalid_redirect_uri", req.RedirectURI)
 				}
 				return fmt.Sprintf("%s?state=%s&code=%s", req.RedirectURI, req.State, "AUTH_CODE")

--- a/e2e_test/pkce_test.go
+++ b/e2e_test/pkce_test.go
@@ -40,7 +40,7 @@ func TestPKCE(t *testing.T) {
 					t.Errorf("scope wants %s but %s", want, req.Scope)
 					return fmt.Sprintf("%s?error=invalid_scope", req.RedirectURI)
 				}
-				if !assertRedirectURI(t, req.RedirectURI, "http", "localhost", "/") {
+				if !assertRedirectURI(t, req.RedirectURI, "http", "localhost", "") {
 					return fmt.Sprintf("%s?error=invalid_redirect_uri", req.RedirectURI)
 				}
 				return fmt.Sprintf("%s?state=%s&code=%s", req.RedirectURI, req.State, "AUTH_CODE")

--- a/e2e_test/tls_test.go
+++ b/e2e_test/tls_test.go
@@ -31,7 +31,7 @@ func TestTLS(t *testing.T) {
 					t.Errorf("scope wants %s but %s", want, req.Scope)
 					return fmt.Sprintf("%s?error=invalid_scope", req.RedirectURI)
 				}
-				if !assertRedirectURI(t, req.RedirectURI, "https", "localhost", "/") {
+				if !assertRedirectURI(t, req.RedirectURI, "https", "localhost", "") {
 					return fmt.Sprintf("%s?error=invalid_redirect_uri", req.RedirectURI)
 				}
 				return fmt.Sprintf("%s?state=%s&code=%s", req.RedirectURI, req.State, "AUTH_CODE")

--- a/oauth2cli.go
+++ b/oauth2cli.go
@@ -85,7 +85,6 @@ type Config struct {
 
 	// Callback path of the local server.
 	// If your provider requires a specific path of the redirect URL, set it here.
-	// Default to "/".
 	LocalServerCallbackPath string
 
 	// Response HTML body on authorization completed.
@@ -123,9 +122,6 @@ func (cfg *Config) validateAndSetDefaults() error {
 			return fmt.Errorf("could not generate a state parameter: %w", err)
 		}
 		cfg.State = state
-	}
-	if cfg.LocalServerCallbackPath == "" {
-		cfg.LocalServerCallbackPath = "/"
 	}
 	if cfg.LocalServerMiddleware == nil {
 		cfg.LocalServerMiddleware = noopMiddleware

--- a/server.go
+++ b/server.go
@@ -130,13 +130,17 @@ type localServerHandler struct {
 }
 
 func (h *localServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	callbackPath := h.config.LocalServerCallbackPath
+	if callbackPath == "" {
+		callbackPath = "/"
+	}
 	q := r.URL.Query()
 	switch {
-	case r.Method == "GET" && r.URL.Path == h.config.LocalServerCallbackPath && q.Get("error") != "":
+	case r.Method == "GET" && r.URL.Path == callbackPath && q.Get("error") != "":
 		h.onceRespCh.Do(func() {
 			h.respCh <- h.handleErrorResponse(w, r)
 		})
-	case r.Method == "GET" && r.URL.Path == h.config.LocalServerCallbackPath && q.Get("code") != "":
+	case r.Method == "GET" && r.URL.Path == callbackPath && q.Get("code") != "":
 		h.onceRespCh.Do(func() {
 			h.respCh <- h.handleCodeResponse(w, r)
 		})


### PR DESCRIPTION
Before v1.15.0, the redirect URL does not have a trailing slash. This change removes the trailing slash when 
LocalServerCallbackPath is a zero value.